### PR TITLE
fix null pointer exception when zookeeper master zonde connection lost

### DIFF
--- a/guagua-mapreduce/src/main/java/ml/shifu/guagua/mapreduce/GuaguaMapReduceClient.java
+++ b/guagua-mapreduce/src/main/java/ml/shifu/guagua/mapreduce/GuaguaMapReduceClient.java
@@ -175,6 +175,9 @@ public class GuaguaMapReduceClient {
             for(ControlledJob controlledJob: runningJobs) {
                 String jobId = controlledJob.getJob().getJobID().toString();
                 Counters counters = getCounters(controlledJob.getJob());
+                if (counters == null) {
+                    continue;
+                }
                 Counter doneMaster = counters.findCounter(GuaguaMapReduceConstants.GUAGUA_STATUS,
                         GuaguaMapReduceConstants.MASTER_SUCCESS);
                 Counter doneWorkers = counters.findCounter(GuaguaMapReduceConstants.GUAGUA_STATUS,


### PR DESCRIPTION
一个train hadoop job由于master znode挂了，getCounters(jobId) 返回的Counter是null